### PR TITLE
Add ngrok subdomain support

### DIFF
--- a/charts/ngrok/README.md
+++ b/charts/ngrok/README.md
@@ -41,6 +41,7 @@ Parameter | Description | Default
 `service.type` | type of service | `ClusterIP`
 `token` | Ngrok auth token | `none`
 `expose.service` | Service address to be exposed as in `service-name:port` | `none`
+`subdomain` | Ngrok subdomain | `none`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/ngrok/templates/deployment.yaml
+++ b/charts/ngrok/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
           command:
             - ./ngrok
             - http
+            {{ if .Values.subdomain }}- --subdomain={{ .Values.subdomain }}{{ end }}
             - {{ .Values.expose.service }}
           volumeMounts:
           - name: config

--- a/charts/ngrok/values.yaml
+++ b/charts/ngrok/values.yaml
@@ -23,3 +23,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+subdomain:


### PR DESCRIPTION
I added the ability to manually specify a custom ngrok subdomain (useful for paid ngrok accounts).