### PR TITLE
Fix the UI XHRs when the webserver is mounted at a non-root URL

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "1.4.3"
+var VERSION = "1.4.4"
 var REVISION = "unknown"

--- a/ui/vue.html
+++ b/ui/vue.html
@@ -147,7 +147,7 @@
         getInfo: function() {
             var xhr = new XMLHttpRequest()
             var self = this
-            xhr.open('GET', "/api/info")
+            xhr.open('GET', "api/info")
             xhr.onload = function () {
                 data = JSON.parse(xhr.responseText)
                 // reload page when the version changes
@@ -170,7 +170,7 @@
         },
         postBackend: function() {
             var self = this
-            fetch("/api/echo", {
+            fetch("api/echo", {
                 method: 'post',
                 headers: {
                 "Content-type": "application/json; charset=UTF-8",


### PR DESCRIPTION
I'm exposing podinfo behind an Ingress at the `/podinfo` URL, and this patch is needed for the UI to function correctly.

Thanks!