### PR TITLE
fix(doc): Update README about read/write endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Web API:
 * `POST /token` issues a JWT token valid for one minute `JWT=$(curl -sd 'anon' podinfo:9898/token | jq -r .token)`
 * `GET /token/validate` validates the JWT token `curl -H "Authorization: Bearer $JWT" podinfo:9898/token/validate`
 * `GET /configs` returns a JSON with configmaps and/or secrets mounted in the `config` volume
-* `POST /write` writes the posted content to disk at /data/hash and returns the SHA1 hash of the content
-* `GET /read/{hash}` returns the content of the file /data/hash if exists
+* `POST /store` writes the posted content to disk at /data/hash and returns the SHA1 hash of the content
+* `GET /store/{hash}` returns the content of the file /data/hash if exists
 * `GET /ws/echo` echos content via websockets `podcli ws ws://localhost:9898/ws/echo`
 
 ### Guides


### PR DESCRIPTION
Hey! Thanks a lot for developing and sharing podinfo. This is so handy ☺️ 

I was following https://github.com/stefanprodan/k8s-podinfo/blob/master/docs/1-deploy.md#using-the-helm-chart and `helm test` failed.

The cause seemed like changes in two endpoints. `POST /write` seems to have changed to `POST /store`, and `GET /read/{hash}` to `GET /store/{hash}`. Here's the fix just for README, according to my observation :)

// I should have fixed `/scripts/ping.sh` as well so that `helm test` passes, but had no time!