### PR TITLE
Add option to run the metrics exporter on a different port

### DIFF
--- a/cmd/podinfo/main.go
+++ b/cmd/podinfo/main.go
@@ -21,6 +21,7 @@ func main() {
 	// flags definition
 	fs := pflag.NewFlagSet("default", pflag.ContinueOnError)
 	fs.Int("port", 9898, "port")
+	fs.Int("port-metrics", 0, "metrics port")
 	fs.String("level", "info", "log level debug, info, warn, error, flat or panic")
 	fs.String("backend-url", "", "backend service URL")
 	fs.Duration("http-client-timeout", 2*time.Minute, "client timeout duration")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "1.5.1"
+var VERSION = "1.6.0"
 var REVISION = "unknown"


### PR DESCRIPTION
Add `-port-metrics` flag, when specified the Prometheus `/metrics` endpoint will be exposed on that port.