### PR TITLE
Upgrade to vuetify 2.x

### DIFF
--- a/ui/vue.html
+++ b/ui/vue.html
@@ -125,12 +125,14 @@
     </v-content>
   </v-app>
  </div>
- <script src="https://unpkg.com/vue/dist/vue.min.js"></script>
- <script src="https://unpkg.com/vuetify/dist/vuetify.min.js"></script>
+
+ <script src="https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js"></script>
+ <script src="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js"></script>
  <script>
    new Vue({
     delimiters: ['${', '}'],
     el: '#app',
+    vuetify: new Vuetify(),
     data: function() {
     return {
         info: {},


### PR DESCRIPTION
This fixes an error that is preventing the UI from working for me:

```
[Vue warn]: Error in getter for watcher "isDark": "TypeError: Cannot read property 'dark' of undefined"
```

Looks like an API change between vuetify 1.x and 2.x.