### PR TITLE
Add delayed chunk endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Web API:
 * `POST /store` writes the posted content to disk at /data/hash and returns the SHA1 hash of the content
 * `GET /store/{hash}` returns the content of the file /data/hash if exists
 * `GET /ws/echo` echos content via websockets `podcli ws ws://localhost:9898/ws/echo`
+* `GET /chunked/{seconds}` uses `transfer-encoding` type `chunked` to give a partial response and then waits for the specified period
 
 ### Guides
 

--- a/pkg/api/chunked.go
+++ b/pkg/api/chunked.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+func (s *Server) chunkedHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	delay, err := strconv.Atoi(vars["wait"])
+	if err != nil {
+		delay = rand.Intn(int(s.config.HttpServerTimeout*time.Second)-10) + 10
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		s.ErrorResponse(w, r, "Streaming unsupported!", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Connection", "Keep-Alive")
+	w.Header().Set("Transfer-Encoding", "chunked")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	flusher.Flush()
+
+	time.Sleep(time.Duration(delay) * time.Second)
+	s.JSONResponse(w, r, map[string]int{"delay": delay})
+
+	flusher.Flush()
+}

--- a/pkg/api/chunked_test.go
+++ b/pkg/api/chunked_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+)
+
+func TestChunkedHandler(t *testing.T) {
+	req, err := http.NewRequest("GET", "/chunked/0", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	srv := NewMockServer()
+
+	srv.router.HandleFunc("/chunked/{wait}", srv.chunkedHandler)
+	srv.router.ServeHTTP(rr, req)
+
+	// Check the status code is what we expect.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check the response body is what we expect.
+	expected := ".*delay.*0.*"
+	r := regexp.MustCompile(expected)
+	if !r.MatchString(rr.Body.String()) {
+		t.Fatalf("handler returned unexpected body:\ngot \n%v \nwant \n%s",
+			rr.Body.String(), expected)
+	}
+}

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"regexp"
@@ -51,7 +52,7 @@ func (p *PrometheusMiddleware) Handler(next http.Handler) http.Handler {
 		begin := time.Now()
 		interceptor := &interceptor{ResponseWriter: w, statusCode: http.StatusOK}
 		path := p.getRouteName(r)
-		next.ServeHTTP(interceptor, r)
+		next.ServeHTTP(interceptor.wrappedResponseWriter(), r)
 		var (
 			status = strconv.Itoa(interceptor.statusCode)
 			took   = time.Since(begin)
@@ -94,6 +95,14 @@ type interceptor struct {
 	recorded   bool
 }
 
+func (i *interceptor) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := i.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("interceptor: can't cast parent ResponseWriter to Hijacker")
+	}
+	return hj.Hijack()
+}
+
 func (i *interceptor) WriteHeader(code int) {
 	if !i.recorded {
 		i.statusCode = code
@@ -102,10 +111,262 @@ func (i *interceptor) WriteHeader(code int) {
 	i.ResponseWriter.WriteHeader(code)
 }
 
-func (i *interceptor) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	hj, ok := i.ResponseWriter.(http.Hijacker)
-	if !ok {
-		return nil, nil, fmt.Errorf("interceptor: can't cast parent ResponseWriter to Hijacker")
+// Returns a wrapped http.ResponseWriter that implements the same optional interfaces
+// that the underlying ResponseWriter has.
+// Handle every possible combination so that code that checks for the existence of each
+// optional interface functions properly.
+// Based on https://github.com/felixge/httpsnoop/blob/eadd4fad6aac69ae62379194fe0219f3dbc80fd3/wrap_generated_gteq_1.8.go#L66
+func (i *interceptor) wrappedResponseWriter() http.ResponseWriter {
+	closeNotifier, isCloseNotifier := i.ResponseWriter.(http.CloseNotifier)
+	flush, isFlusher := i.ResponseWriter.(http.Flusher)
+	hijack, isHijacker := i.ResponseWriter.(http.Hijacker)
+	push, isPusher := i.ResponseWriter.(http.Pusher)
+	readFrom, isReaderFrom := i.ResponseWriter.(io.ReaderFrom)
+
+	switch {
+	case !isCloseNotifier && !isFlusher && !isHijacker && !isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+		}{i}
+
+	case isCloseNotifier && !isFlusher && !isHijacker && !isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+		}{i, closeNotifier}
+
+	case !isCloseNotifier && isFlusher && !isHijacker && !isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+		}{i, flush}
+
+	case !isCloseNotifier && !isFlusher && isHijacker && !isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+		}{i, hijack}
+
+	case !isCloseNotifier && !isFlusher && !isHijacker && isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Pusher
+		}{i, push}
+
+	case !isCloseNotifier && !isFlusher && !isHijacker && !isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			io.ReaderFrom
+		}{i, readFrom}
+
+	case isCloseNotifier && isFlusher && !isHijacker && !isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Flusher
+		}{i, closeNotifier, flush}
+
+	case isCloseNotifier && !isFlusher && isHijacker && !isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+		}{i, closeNotifier, hijack}
+
+	case isCloseNotifier && !isFlusher && !isHijacker && isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Pusher
+		}{i, closeNotifier, push}
+
+	case isCloseNotifier && !isFlusher && !isHijacker && !isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+		}{i, closeNotifier, readFrom}
+
+	case !isCloseNotifier && isFlusher && isHijacker && !isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+		}{i, flush, hijack}
+
+	case !isCloseNotifier && isFlusher && !isHijacker && isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Pusher
+		}{i, flush, push}
+
+	case !isCloseNotifier && isFlusher && !isHijacker && !isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+		}{i, flush, readFrom}
+
+	case !isCloseNotifier && !isFlusher && isHijacker && isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.Pusher
+		}{i, hijack, push}
+
+	case !isCloseNotifier && !isFlusher && isHijacker && !isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+		}{i, hijack, readFrom}
+
+	case !isCloseNotifier && !isFlusher && !isHijacker && isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Pusher
+			io.ReaderFrom
+		}{i, push, readFrom}
+
+	case isCloseNotifier && isFlusher && isHijacker && !isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Flusher
+			http.Hijacker
+		}{i, closeNotifier, flush, hijack}
+
+	case isCloseNotifier && isFlusher && !isHijacker && isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Flusher
+			http.Pusher
+		}{i, closeNotifier, flush, push}
+
+	case isCloseNotifier && isFlusher && !isHijacker && !isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Flusher
+			io.ReaderFrom
+		}{i, closeNotifier, flush, readFrom}
+
+	case isCloseNotifier && !isFlusher && isHijacker && isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			http.Pusher
+		}{i, closeNotifier, hijack, push}
+
+	case isCloseNotifier && !isFlusher && isHijacker && !isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+		}{i, closeNotifier, hijack, readFrom}
+
+	case isCloseNotifier && !isFlusher && !isHijacker && isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Pusher
+			io.ReaderFrom
+		}{i, closeNotifier, push, readFrom}
+
+	case !isCloseNotifier && isFlusher && isHijacker && isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			http.Pusher
+		}{i, flush, hijack, push}
+
+	case !isCloseNotifier && isFlusher && isHijacker && !isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+		}{i, flush, hijack, readFrom}
+
+	case !isCloseNotifier && isFlusher && !isHijacker && isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Pusher
+			io.ReaderFrom
+		}{i, flush, push, readFrom}
+
+	case !isCloseNotifier && !isFlusher && isHijacker && isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+		}{i, hijack, push, readFrom}
+
+	case isCloseNotifier && isFlusher && isHijacker && isPusher && !isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Flusher
+			http.Hijacker
+			http.Pusher
+		}{i, closeNotifier, flush, hijack, push}
+
+	case isCloseNotifier && isFlusher && isHijacker && !isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+		}{i, closeNotifier, flush, hijack, readFrom}
+
+	case isCloseNotifier && isFlusher && !isHijacker && isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Flusher
+			http.Pusher
+			io.ReaderFrom
+		}{i, closeNotifier, flush, push, readFrom}
+
+	case isCloseNotifier && !isFlusher && isHijacker && isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+		}{i, closeNotifier, hijack, push, readFrom}
+
+	case !isCloseNotifier && isFlusher && isHijacker && isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+		}{i, flush, hijack, push, readFrom}
+
+	case isCloseNotifier && isFlusher && isHijacker && isPusher && isReaderFrom:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Flusher
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+		}{i, closeNotifier, flush, hijack, push, readFrom}
+
+	default:
+		return struct {
+			http.ResponseWriter
+		}{i}
 	}
-	return hj.Hijack()
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -3,17 +3,18 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/spf13/viper"
-	"github.com/stefanprodan/k8s-podinfo/pkg/fscache"
-	"go.uber.org/zap"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/spf13/viper"
+	"github.com/stefanprodan/k8s-podinfo/pkg/fscache"
+	"go.uber.org/zap"
 )
 
 var (
@@ -80,6 +81,8 @@ func (s *Server) registerHandlers() {
 	s.router.HandleFunc("/api/info", s.infoHandler).Methods("GET")
 	s.router.HandleFunc("/api/echo", s.echoHandler).Methods("POST")
 	s.router.HandleFunc("/ws/echo", s.echoWsHandler)
+	s.router.HandleFunc("/chunked", s.chunkedHandler)
+	s.router.HandleFunc("/chunked/{wait:[0-9]+}", s.chunkedHandler)
 }
 
 func (s *Server) registerMiddlewares() {


### PR DESCRIPTION
Adds an endpoint that does chunk based encoding. The endpoint just stalls
and eventually returns the stall time.

Similar to the delay endpoint but in a chunked maner.

Fixed up the metrics interceptor to wrap ResponseWriter correctly too.